### PR TITLE
pytest-xdist

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ python:
   - "2.6"
   - "2.7"
   - "3.5"
+  - "3.6"
 
 install:
   - pip install tox

--- a/pytest_random_order/plugin.py
+++ b/pytest_random_order/plugin.py
@@ -19,7 +19,7 @@ def pytest_addoption(parser):
         '--random-order-seed',
         action='store',
         dest='random_order_seed',
-        default=None,
+        default=str(random.randint(1, 1000000)),
         help='Seed for the test order randomiser to produce a random order that can be reproduced using this seed',
     )
 
@@ -27,22 +27,15 @@ def pytest_addoption(parser):
 def pytest_configure(config):
     config.addinivalue_line("markers", "random_order(disabled=True): disable reordering of tests within a module or class")
 
-    if config.getoption('random_order_seed'):
-        seed = str(config.getoption('random_order_seed'))
-    else:
-        seed = str(random.randint(1, 1000000))
-    config.random_order_seed = seed
-
 
 def pytest_report_header(config):
     out = ''
 
     if config.getoption('random_order_bucket'):
-        bucket = config.getoption('random_order_bucket')
-        out += "Using --random-order-bucket={0}\n".format(bucket)
+        out += "Using --random-order-bucket={0}\n".format(config.getoption('random_order_bucket'))
 
-    if hasattr(config, 'random_order_seed'):
-        out += 'Using --random-order-seed={0}\n'.format(getattr(config, 'random_order_seed'))
+    if config.getoption('random_order_seed'):
+        out += 'Using --random-order-seed={0}\n'.format(config.getoption('random_order_seed'))
 
     return out
 
@@ -53,7 +46,7 @@ def pytest_collection_modifyitems(session, config, items):
     item_ids = _get_set_of_item_ids(items)
 
     try:
-        seed = getattr(config, 'random_order_seed', None)
+        seed = str(config.getoption('random_order_seed'))
         bucket_type = config.getoption('random_order_bucket')
         if bucket_type != 'none':
             _shuffle_items(items, bucket_key=_random_order_item_keys[bucket_type], disable=_disable, seed=seed)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
-pytest
-tox
 coverage
 py
-
+pytest
+pytest-xdist
 sphinx
-
+tox

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ def read(fname):
 
 setup(
     name='pytest-random-order',
-    version='0.5.6',
+    version='0.6.0',
     author='Jazeps Basko',
     author_email='jazeps.basko@gmail.com',
     maintainer='Jazeps Basko',
@@ -35,6 +35,7 @@ setup(
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
         'License :: OSI Approved :: MIT License',
     ],
     entry_points={

--- a/tox.ini
+++ b/tox.ini
@@ -3,8 +3,10 @@
 envlist = py26,py27,py3,flake8
 
 [testenv]
-deps = pytest
-commands = py.test {posargs:tests}
+deps =
+    pytest
+    pytest-xdist
+commands = py.test -n 2 {posargs:tests}
 
 [testenv:py26]
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -11,6 +11,7 @@ commands = py.test -n 2 {posargs:tests}
 [testenv:py26]
 deps =
     pytest
+    pytest-xdist
     ordereddict
 
 [testenv:flake8]


### PR DESCRIPTION
Make it work with pytest-xdist as requested in #22 - generate random order seed during command line argument initialisation so that all processes get the same default value.