### PR TITLE
Fixes randomisation of doctests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ python:
 
 install:
   - pip install tox
-  - "TOX_ENV=${TRAVIS_PYTHON_VERSION/[0-9].[0-9]/py${TRAVIS_PYTHON_VERSION/.}}"
+  - "TOX_ENV=${TRAVIS_PYTHON_VERSION/[0-9].[0-9]/py${TRAVIS_PYTHON_VERSION/.}-pytest4}"
 script: tox -e $TOX_ENV
 
 before_cache:

--- a/README.rst
+++ b/README.rst
@@ -56,7 +56,7 @@ test modules (which is the default behaviour of the plugin), run pytest as follo
     $ pytest --random-order
 
 To change the scope of re-ordering, run pytest with ``--random-order-bucket=<bucket-type>`` option
-where ``<bucket-type>`` can be ``class``, ``module``, ``package``, ``global``, or ``none``:
+where ``<bucket-type>`` can be ``class``, ``module``, ``package``, ``global``:
 
 ::
 
@@ -123,8 +123,9 @@ grandparent
 global
     All tests fall in the same bucket, full randomness, tests probably take longer to run.
 
-none
-    Disable shuffling.
+none (deprecated)
+    Disable shuffling. *Deprecated since 1.0.4 because this plugin no longer shuffles tests by default
+    so there is nothing to disable.*
 
 
 If you have three buckets of tests ``A``, ``B``, and ``C`` with three tests ``1`` and ``2``, and ``3`` in each of them,
@@ -232,6 +233,14 @@ from being registered so its hooks won't be registered and its command line opti
 --------------
 Changelog
 --------------
+
+v1.0.4 (2018-11-30)
++++++++++++++++++++
+
+* Fixes issues with doctests reported in #36 - ``class``, ``package`` and ``module`` didn't work
+  because ``DoctestItem`` doesn't have ``cls`` or ``module`` attributes. Thanks @tobywf.
+* Deprecate ``none`` bucket type.
+* With tox, run tests of pytest-random-order with both pytest 3 and 4.
 
 v1.0.3 (2018-11-16)
 +++++++++++++++++++

--- a/random_order/bucket_types.py
+++ b/random_order/bucket_types.py
@@ -1,4 +1,5 @@
 import functools
+import os.path
 from collections import OrderedDict
 
 bucket_type_keys = OrderedDict()
@@ -34,16 +35,20 @@ def get_global_key(item):
 
 @bucket_type_key('package')
 def get_package_key(item):
+    if not hasattr(item, "module"):
+        return os.path.split(item.location[0])[0]
     return item.module.__package__
 
 
 @bucket_type_key('module')
 def get_module_key(item):
-    return item.module.__name__
+    return item.location[0]
 
 
 @bucket_type_key('class')
 def get_class_key(item):
+    if not hasattr(item, "cls"):
+        return item.location[0]
     if item.cls:
         return item.module.__name__, item.cls.__name__
     else:

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ def read(fname):
 
 setup(
     name='pytest-random-order',
-    version='1.0.3',
+    version='1.0.4',
     author='Jazeps Basko',
     author_email='jazeps.basko@gmail.com',
     maintainer='Jazeps Basko',

--- a/tests/test_doctests.py
+++ b/tests/test_doctests.py
@@ -1,0 +1,56 @@
+# -*- coding: utf-8 -*-
+import py
+import pytest
+
+
+@pytest.fixture
+def tmp_tree_of_tests(testdir):
+    """
+    Creates a directory structure:
+        tmpdir/
+            foo.py
+
+    """
+
+    utils_package = testdir.mkpydir('utils')
+    utils_package.join('__init__.py').write('')
+
+    utils_package.join('foo.py').write(py.code.Source('''
+        def add(a, b):
+            """
+            >>> add(1, 1)
+            2
+            >>> add(0, 0)
+            0
+            """
+            return a + b
+
+        def subtract(a, b):
+            """
+            >>> subtract(1, 1)
+            0
+            >>> subtract(0, 2)
+            -2
+            """
+            return a - b
+    '''))
+
+    return testdir
+
+
+@pytest.mark.parametrize('bucket', [
+    'global',
+    'package',
+    'module',
+    'class',
+    'parent',
+    'grandparent',
+    'none',
+])
+def test_doctests(tmp_tree_of_tests, get_test_calls, bucket):
+    result1 = tmp_tree_of_tests.runpytest(
+        '--doctest-modules', '--random-order-bucket={0}'.format(bucket), '--verbose', '-s',
+    )
+    result1.assert_outcomes(passed=2, failed=0)
+    assert 'PytestWarning' not in result1.stdout.str()
+    assert 'PytestWarning' not in result1.stderr.str()

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,17 @@
 [tox]
-envlist = py{35,36,37},flake8
+envlist =
+    py35-pytest{32,39,4},
+    py36-pytest{32,39,4},
+    py37-pytest{32,39,4},
+    flake8
 
 [testenv]
 deps =
-    pytest
+    pytest32: pytest >=3.2.0, <3.3.0
+    pytest39: pytest >=3.9.0, <4.0.0
+    pytest4: pytest >=4.0.0
     pytest-xdist
+
 commands = py.test -n 2 {posargs:tests}
 
 [testenv:flake8]


### PR DESCRIPTION
* Fixes issues with doctests reported in #36 - ``class``, ``package``…and ``module`` didn't work because ``DoctestItem`` doesn't have ``cls`` or ``module`` attributes. Thanks @tobywf.
* Deprecates ``none`` bucket type.
* With tox, run tests of pytest-random-order with both pytest 3 and 4.