### PR TITLE
Update plugin.py: Failed First Plugin should be processed only when Cache is Enabled

### DIFF
--- a/random_order/plugin.py
+++ b/random_order/plugin.py
@@ -69,7 +69,8 @@ def pytest_collection_modifyitems(session, config, items):
     failure = None
 
     session.random_order_bucket_type_key_handlers = []
-    process_failed_first_last_failed(session, config, items)
+    if config.cache:
+        process_failed_first_last_failed(session, config, items)
 
     item_ids = _get_set_of_item_ids(items)
 

--- a/random_order/plugin.py
+++ b/random_order/plugin.py
@@ -69,7 +69,7 @@ def pytest_collection_modifyitems(session, config, items):
     failure = None
 
     session.random_order_bucket_type_key_handlers = []
-    if config.cache:
+    if hasattr(config, "cache"):
         process_failed_first_last_failed(session, config, items)
 
     item_ids = _get_set_of_item_ids(items)


### PR DESCRIPTION
Update plugin.py: Failed First Plugin should be processed only when Cache is Enabled

Fix: 
https://github.com/jbasko/pytest-random-order/issues/54
https://github.com/pytest-dev/pytest/issues/9250


<img width="943" alt="image" src="https://github.com/jbasko/pytest-random-order/assets/94177510/949916c8-3b51-4325-84f1-b9019e79e79f">
